### PR TITLE
[CLOUD-320] Vendor Mixlib::Authentication

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,27 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
-task :default => :spec
+require "automatiek"
 
+task :default => :spec
 RSpec::Core::RakeTask.new(:spec)
+
+# Vendor Mixlib::Authentication and update all vendored 'require' entries
+# with the vendored path.
+Automatiek::RakeTask.new("mixlib-authentication") do |lib|
+  lib.download = { github: "https://github.com/chef/mixlib-authentication" }
+  lib.vendor_lib = "lib/automate_liveness_agent/vendor/mixlib-authentication"
+
+  mixin = Module.new do
+    def namespace_files
+      require_target = vendor_lib.sub(%r{^(.+?/)?lib/}, "") << "/lib"
+      relative_files = files.map do |f|
+        Pathname.new(f).relative_path_from(Pathname.new(vendor_lib) / "lib").sub_ext("").to_s
+      end
+      process_files(
+        /require (['"])(#{Regexp.union(relative_files)})/,
+        "require \\1#{require_target}/\\2"
+      )
+    end
+  end
+  lib.send(:extend, mixin)
+end

--- a/automate-liveness-agent.gemspec
+++ b/automate-liveness-agent.gemspec
@@ -28,8 +28,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "mixlib-authentication", "~> 1.4"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "automatiek"
 end

--- a/lib/automate_liveness_agent/api_client.rb
+++ b/lib/automate_liveness_agent/api_client.rb
@@ -1,9 +1,9 @@
 require "automate_liveness_agent/version"
 require "automate_liveness_agent/config"
 require "openssl"
-require "mixlib/authentication/signedheaderauth"
 require "net/http"
 require "uri"
+require "automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication/signedheaderauth"
 
 module AutomateLivenessAgent
 

--- a/lib/automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication.rb
+++ b/lib/automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication.rb
@@ -1,0 +1,46 @@
+#
+# Author:: Christopher Brown (<cb@opscode.com>)
+# Copyright:: Copyright (c) 2009 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Mixlib
+  module Authentication
+    DEFAULT_SERVER_API_VERSION = "0"
+
+    attr_accessor :logger
+    module_function :logger, :logger=
+
+    class AuthenticationError < StandardError
+    end
+
+    class MissingAuthenticationHeader < AuthenticationError
+    end
+
+    class Log
+    end
+
+    begin
+      require "mixlib/log"
+      Mixlib::Authentication::Log.extend(Mixlib::Log)
+    rescue LoadError
+      require "automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication/null_logger"
+      Mixlib::Authentication::Log.extend(Mixlib::Authentication::NullLogger)
+    end
+
+    Mixlib::Authentication.logger = Mixlib::Authentication::Log
+    Mixlib::Authentication.logger.level = :error
+  end
+end

--- a/lib/automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication/digester.rb
+++ b/lib/automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication/digester.rb
@@ -1,0 +1,46 @@
+#
+# Author:: Christopher Brown (<cb@opscode.com>)
+# Copyright:: Copyright (c) 2009 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication"
+require "openssl"
+
+module Mixlib
+  module Authentication
+    class Digester
+      class << self
+
+        def hash_file(f, digest = OpenSSL::Digest::SHA1)
+          digester = digest.new
+          buf = ""
+          digester.update buf while f.read(16384, buf)
+          ::Base64.encode64(digester.digest).chomp
+        end
+
+        # Digests a string, base64's and chomps the end
+        #
+        # ====Parameters
+        #
+        def hash_string(str, digest = OpenSSL::Digest::SHA1)
+          ::Base64.encode64(digest.digest(str)).chomp
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication/http_authentication_request.rb
+++ b/lib/automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication/http_authentication_request.rb
@@ -1,0 +1,89 @@
+#
+# Author:: Daniel DeLeo (<dan@opscode.com>)
+# Copyright:: Copyright (c) 2010 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication"
+
+module Mixlib
+  module Authentication
+    class HTTPAuthenticationRequest
+
+      MANDATORY_HEADERS = [:x_ops_sign, :x_ops_userid, :x_ops_timestamp, :host, :x_ops_content_hash]
+
+      attr_reader :request
+
+      def initialize(request)
+        @request = request
+        @request_signature = nil
+        validate_headers!
+      end
+
+      def headers
+        @headers ||= @request.env.inject({}) { |memo, kv| memo[$2.tr("-", "_").downcase.to_sym] = kv[1] if kv[0] =~ /^(HTTP_)(.*)/; memo }
+      end
+
+      def http_method
+        @request.method.to_s
+      end
+
+      def path
+        @request.path.to_s
+      end
+
+      def signing_description
+        headers[:x_ops_sign].chomp
+      end
+
+      def user_id
+        headers[:x_ops_userid].chomp
+      end
+
+      def timestamp
+        headers[:x_ops_timestamp].chomp
+      end
+
+      def host
+        headers[:host].chomp
+      end
+
+      def content_hash
+        headers[:x_ops_content_hash].chomp
+      end
+
+      def server_api_version
+        (headers[:x_ops_server_api_version] || DEFAULT_SERVER_API_VERSION).chomp
+      end
+
+      def request_signature
+        unless @request_signature
+          @request_signature = headers.find_all { |h| h[0].to_s =~ /^x_ops_authorization_/ }
+            .sort { |x, y| x.to_s[/\d+/].to_i <=> y.to_s[/\d+/].to_i }.map { |i| i[1] }.join("\n")
+          Mixlib::Authentication::Log.debug "Reconstituted (user-supplied) request signature: #{@request_signature}"
+        end
+        @request_signature
+      end
+
+      def validate_headers!
+        missing_headers = MANDATORY_HEADERS - headers.keys
+        unless missing_headers.empty?
+          missing_headers.map! { |h| h.to_s.upcase }
+          raise MissingAuthenticationHeader, "missing required authentication header(s) '#{missing_headers.join("', '")}'"
+        end
+      end
+    end
+  end
+end

--- a/lib/automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication/null_logger.rb
+++ b/lib/automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication/null_logger.rb
@@ -1,0 +1,24 @@
+module Mixlib
+  module Authentication
+    module NullLogger
+
+      attr_accessor :level
+
+      %i{debug info warn error fatal}.each do |method_name|
+        class_eval(<<-METHOD_DEFN, __FILE__, __LINE__)
+          def #{method_name}(msg=nil, &block)
+            true
+          end
+        METHOD_DEFN
+      end
+
+      %i{debug? info? warn? error? fatal?}.each do |method_name|
+        class_eval(<<-METHOD_DEFN, __FILE__, __LINE__)
+          def #{method_name}
+            false
+          end
+        METHOD_DEFN
+      end
+    end
+  end
+end

--- a/lib/automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication/signatureverification.rb
+++ b/lib/automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication/signatureverification.rb
@@ -1,0 +1,241 @@
+#
+# Author:: Christopher Brown (<cb@opscode.com>)
+# Author:: Christopher Walters (<cw@opscode.com>)
+# Copyright:: Copyright (c) 2009, 2010 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "net/http"
+require "forwardable"
+require "automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication"
+require "automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication/http_authentication_request"
+require "automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication/signedheaderauth"
+
+module Mixlib
+  module Authentication
+    SignatureResponse = Struct.new(:name)
+
+    class SignatureVerification
+      extend Forwardable
+
+      def_delegator :@auth_request, :http_method
+
+      def_delegator :@auth_request, :path
+
+      def_delegator :@auth_request, :signing_description
+
+      def_delegator :@auth_request, :user_id
+
+      def_delegator :@auth_request, :timestamp
+
+      def_delegator :@auth_request, :host
+
+      def_delegator :@auth_request, :request_signature
+
+      def_delegator :@auth_request, :content_hash
+
+      def_delegator :@auth_request, :request
+
+      def_delegator :@auth_request, :server_api_version
+
+      include Mixlib::Authentication::SignedHeaderAuth
+
+      def initialize(request = nil)
+        @auth_request = HTTPAuthenticationRequest.new(request) if request
+
+        @valid_signature, @valid_timestamp, @valid_content_hash = false, false, false
+
+        @hashed_body = nil
+      end
+
+      def authenticate_user_request(request, user_lookup, time_skew = (15 * 60))
+        @auth_request = HTTPAuthenticationRequest.new(request)
+        authenticate_request(user_lookup, time_skew)
+      end
+
+      # Takes the request, boils down the pieces we are interested in,
+      # looks up the user, generates a signature, and compares to
+      # the signature in the request
+      # ====Headers
+      #
+      # X-Ops-Sign: algorithm=sha1;version=1.0;
+      # X-Ops-UserId: <user_id>
+      # X-Ops-Timestamp:
+      # X-Ops-Content-Hash:
+      # X-Ops-Authorization-#{line_number}
+      def authenticate_request(user_secret, time_skew = (15 * 60))
+        Mixlib::Authentication.logger.debug "Initializing header auth : #{request.inspect}"
+
+        @user_secret       = user_secret
+        @allowed_time_skew = time_skew # in seconds
+
+        begin
+          parts = parse_signing_description
+
+          # version 1.0 clients don't include their algorithm in the
+          # signing description, so default to sha1
+          parts[:algorithm] ||= "sha1"
+
+          verify_signature(parts[:algorithm], parts[:version])
+          verify_timestamp
+          verify_content_hash
+
+        rescue StandardError => se
+          raise AuthenticationError, "Failed to authenticate user request. Check your client key and clock: #{se.message}", se.backtrace
+        end
+
+        if valid_request?
+          SignatureResponse.new(user_id)
+        else
+          nil
+        end
+      end
+
+      def valid_signature?
+        @valid_signature
+      end
+
+      def valid_timestamp?
+        @valid_timestamp
+      end
+
+      def valid_content_hash?
+        @valid_content_hash
+      end
+
+      def valid_request?
+        valid_signature? && valid_timestamp? && valid_content_hash?
+      end
+
+      # The authorization header is a Base64-encoded version of an RSA signature.
+      # The client sent it on multiple header lines, starting at index 1 -
+      # X-Ops-Authorization-1, X-Ops-Authorization-2, etc. Pull them out and
+      # concatenate.
+      def headers
+        @headers ||= request.env.inject({}) { |memo, kv| memo[$2.tr("-", "_").downcase.to_sym] = kv[1] if kv[0] =~ /^(HTTP_)(.*)/; memo }
+      end
+
+      private
+
+      def assert_required_headers_present
+        MANDATORY_HEADERS.each do |header|
+          unless headers.key?(header)
+            raise MissingAuthenticationHeader, "required authentication header #{header.to_s.upcase} missing"
+          end
+        end
+      end
+
+      def verify_signature(algorithm, version)
+        candidate_block = canonicalize_request(algorithm, version)
+        signature = Base64.decode64(request_signature)
+        @valid_signature = case version
+                           when "1.3"
+                             digest = validate_sign_version_digest!(algorithm, version)
+                             @user_secret.verify(digest.new, signature, candidate_block)
+                           else
+                             request_decrypted_block = @user_secret.public_decrypt(signature)
+                             (request_decrypted_block == candidate_block)
+                           end
+
+        # Keep the debug messages lined up so it's easy to scan them
+        Mixlib::Authentication.logger.debug("Verifying request signature:")
+        Mixlib::Authentication.logger.debug(" Expected Block is: '#{candidate_block}'")
+        Mixlib::Authentication.logger.debug("Decrypted block is: '#{request_decrypted_block}'")
+        Mixlib::Authentication.logger.debug("Signatures match? : '#{@valid_signature}'")
+
+        @valid_signature
+      rescue => e
+        Mixlib::Authentication.logger.debug("Failed to verify request signature: #{e.class.name}: #{e.message}")
+        @valid_signature = false
+      end
+
+      def verify_timestamp
+        @valid_timestamp = timestamp_within_bounds?(Time.parse(timestamp), Time.now)
+      end
+
+      def verify_content_hash
+        @valid_content_hash = (content_hash == hashed_body)
+
+        # Keep the debug messages lined up so it's easy to scan them
+        Mixlib::Authentication.logger.debug("Expected content hash is: '#{hashed_body}'")
+        Mixlib::Authentication.logger.debug(" Request Content Hash is: '#{content_hash}'")
+        Mixlib::Authentication.logger.debug("           Hashes match?: #{@valid_content_hash}")
+
+        @valid_content_hash
+      end
+
+      # The request signature is based on any file attached, if any. Otherwise
+      # it's based on the body of the request.
+      def hashed_body(digest = Digest::SHA1)
+        unless @hashed_body
+          # TODO: tim: 2009-112-28: It'd be nice to remove this special case, and
+          # always hash the entire request body. In the file case it would just be
+          # expanded multipart text - the entire body of the POST.
+          #
+          # Pull out any file that was attached to this request, using multipart
+          # form uploads.
+          # Depending on the server we're running in, multipart form uploads are
+          # handed to us differently.
+          # - In Passenger (Cookbooks Community Site), the File is handed to us
+          #   directly in the params hash. The name is whatever the client used,
+          #   its value is therefore a File or Tempfile.
+          #   e.g. request['file_param'] = File
+          #
+          # - In Merb (Chef server), the File is wrapped. The original parameter
+          #   name used for the file is used, but its value is a Hash. Within
+          #   the hash is a name/value pair named 'file' which actually
+          #   contains the Tempfile instance.
+          #   e.g. request['file_param'] = { :file => Tempfile }
+          file_param = request.params.values.find { |value| value.respond_to?(:read) }
+
+          # No file_param; we're running in Merb, or it's just not there..
+          if file_param.nil?
+            hash_param = request.params.values.find { |value| value.respond_to?(:has_key?) } # Hash responds to :has_key? .
+            if !hash_param.nil?
+              file_param = hash_param.values.find { |value| value.respond_to?(:read) } # File/Tempfile responds to :read.
+            end
+          end
+
+          # Any file that's included in the request is hashed if it's there. Otherwise,
+          # we hash the body.
+          if file_param
+            Mixlib::Authentication.logger.debug "Digesting file_param: '#{file_param.inspect}'"
+            @hashed_body = digester.hash_file(file_param, digest)
+          else
+            body = request.raw_post
+            Mixlib::Authentication.logger.debug "Digesting body: '#{body}'"
+            @hashed_body = digester.hash_string(body, digest)
+          end
+        end
+        @hashed_body
+      end
+
+      # Compare the request timestamp with boundary time
+      #
+      #
+      # ====Parameters
+      # time1<Time>:: minuend
+      # time2<Time>:: subtrahend
+      #
+      def timestamp_within_bounds?(time1, time2)
+        time_diff = (time2 - time1).abs
+        is_allowed = (time_diff < @allowed_time_skew)
+        Mixlib::Authentication.logger.debug "Request time difference: #{time_diff}, within #{@allowed_time_skew} seconds? : #{!!is_allowed}"
+        is_allowed
+      end
+    end
+
+  end
+end

--- a/lib/automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication/signedheaderauth.rb
+++ b/lib/automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication/signedheaderauth.rb
@@ -1,0 +1,288 @@
+#
+# Author:: Christopher Brown (<cb@opscode.com>)
+# Author:: Christopher Walters (<cw@opscode.com>)
+# Copyright:: Copyright (c) 2009, 2010 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "time"
+require "base64"
+require "openssl/digest"
+require "automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication"
+require "automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication/digester"
+
+module Mixlib
+  module Authentication
+
+    module SignedHeaderAuth
+
+      NULL_ARG = Object.new
+
+      ALGORITHM_FOR_VERSION = {
+        "1.0" => "sha1",
+        "1.1" => "sha1",
+        "1.3" => "sha256",
+      }.freeze()
+
+      # Use of SUPPORTED_ALGORITHMS and SUPPORTED_VERSIONS is deprecated. Use
+      # ALGORITHM_FOR_VERSION instead
+      SUPPORTED_ALGORITHMS = ["sha1"].freeze
+      SUPPORTED_VERSIONS = ["1.0", "1.1"].freeze
+
+      DEFAULT_SIGN_ALGORITHM = "sha1".freeze
+      DEFAULT_PROTO_VERSION = "1.0".freeze
+
+      # === signing_object
+      # This is the intended interface for signing requests with the
+      # Opscode/Chef signed header protocol. This wraps the constructor for a
+      # Struct that contains the relevant information about your request.
+      #
+      # ==== Signature Parameters:
+      # These parameters are used to generate the canonical representation of
+      # the request, which is then hashed and encrypted to generate the
+      # request's signature. These options are all required, with the exception
+      # of `:body` and `:file`, which are alternate ways to specify the request
+      # body (you must specify one of these).
+      # * `:http_method`: HTTP method as a lowercase symbol, e.g., `:get | :put | :post | :delete`
+      # * `:path`: The path part of the URI, e.g., `URI.parse(uri).path`
+      # * `:body`: An object representing the body of the request.
+      #   Use an empty String for bodiless requests.
+      # * `:timestamp`: A String representing the time in any format understood
+      #   by `Time.parse`. The server may reject the request if the timestamp is
+      #   not close to the server's current time.
+      # * `:user_id`: The user or client name. This is used by the server to
+      #   lookup the public key necessary to verify the signature.
+      # * `:file`: An IO object (must respond to `:read`) to be used as the
+      #   request body.
+      # ==== Protocol Versioning Parameters:
+      # * `:proto_version`: The version of the signing protocol to use.
+      #   Currently defaults to 1.0, but version 1.1 is also available.
+      # ==== Other Parameters:
+      # These parameters are accepted but not used in the computation of the signature.
+      # * `:host`: The host part of the URI
+      def self.signing_object(args = {})
+        SigningObject.new(args[:http_method],
+                          args[:path],
+                          args[:body],
+                          args[:host],
+                          args[:timestamp],
+                          args[:user_id],
+                          args[:file],
+                          args[:proto_version],
+                          args[:headers]
+                         )
+      end
+
+      def algorithm
+        ALGORITHM_FOR_VERSION[proto_version] || DEFAULT_SIGN_ALGORITHM
+      end
+
+      def proto_version
+        DEFAULT_PROTO_VERSION
+      end
+
+      # Build the canonicalized request based on the method, other headers, etc.
+      # compute the signature from the request, using the looked-up user secret
+      # ====Parameters
+      # private_key<OpenSSL::PKey::RSA>:: user's RSA private key.
+      def sign(private_key, sign_algorithm = algorithm, sign_version = proto_version)
+        digest = validate_sign_version_digest!(sign_algorithm, sign_version)
+        # Our multiline hash for authorization will be encoded in multiple header
+        # lines - X-Ops-Authorization-1, ... (starts at 1, not 0!)
+        header_hash = {
+          "X-Ops-Sign" => "algorithm=#{sign_algorithm};version=#{sign_version};",
+          "X-Ops-Userid" => user_id,
+          "X-Ops-Timestamp" => canonical_time,
+          "X-Ops-Content-Hash" => hashed_body(digest),
+        }
+
+        signature = Base64.encode64(do_sign(private_key, digest, sign_algorithm, sign_version)).chomp
+        signature_lines = signature.split(/\n/)
+        signature_lines.each_index do |idx|
+          key = "X-Ops-Authorization-#{idx + 1}"
+          header_hash[key] = signature_lines[idx]
+        end
+
+        Mixlib::Authentication.logger.debug "Header hash: #{header_hash.inspect}"
+
+        header_hash
+      end
+
+      def validate_sign_version_digest!(sign_algorithm, sign_version)
+        if ALGORITHM_FOR_VERSION[sign_version].nil?
+          raise AuthenticationError,
+            "Unsupported version '#{sign_version}'"
+        end
+
+        if ALGORITHM_FOR_VERSION[sign_version] != sign_algorithm
+          raise AuthenticationError,
+            "Unsupported algorithm #{sign_algorithm} for version '#{sign_version}'"
+        end
+
+        case sign_algorithm
+        when "sha1"
+          OpenSSL::Digest::SHA1
+        when "sha256"
+          OpenSSL::Digest::SHA256
+        else
+          # This case should never happen
+          raise "Unknown algorithm #{sign_algorithm}"
+        end
+      end
+
+      # Build the canonicalized time based on utc & iso8601
+      #
+      # ====Parameters
+      #
+      def canonical_time
+        Time.parse(timestamp).utc.iso8601
+      end
+
+      # Build the canonicalized path, which collapses multiple slashes (/) and
+      # removes a trailing slash unless the path is only "/"
+      #
+      # ====Parameters
+      #
+      def canonical_path
+        p = path.gsub(/\/+/, "/")
+        p.length > 1 ? p.chomp("/") : p
+      end
+
+      def hashed_body(digest = OpenSSL::Digest::SHA1)
+        # This is weird. sign() is called with the digest type and signing
+        # version. These are also expected to be properties of the object.
+        # Hence, we're going to assume the one that is passed to sign is
+        # the correct one and needs to passed through all the functions
+        # that do any sort of digest.
+        @hashed_body_digest = nil unless defined?(@hashed_body_digest)
+        if !@hashed_body_digest.nil? && @hashed_body_digest != digest
+          raise "hashed_body must always be called with the same digest"
+        else
+          @hashed_body_digest = digest
+        end
+        # Hash the file object if it was passed in, otherwise hash based on
+        # the body.
+        # TODO: tim 2009-12-28: It'd be nice to just remove this special case,
+        # always sign the entire request body, using the expanded multipart
+        # body in the case of a file being include.
+        @hashed_body ||= if self.file && self.file.respond_to?(:read)
+                           digester.hash_file(self.file, digest)
+                         else
+                           digester.hash_string(self.body, digest)
+                         end
+      end
+
+      # Takes HTTP request method & headers and creates a canonical form
+      # to create the signature
+      #
+      # ====Parameters
+      #
+      #
+      def canonicalize_request(sign_algorithm = algorithm, sign_version = proto_version)
+        digest = validate_sign_version_digest!(sign_algorithm, sign_version)
+        canonical_x_ops_user_id = canonicalize_user_id(user_id, sign_version, digest)
+        case sign_version
+        when "1.3"
+          [
+            "Method:#{http_method.to_s.upcase}",
+            "Path:#{canonical_path}",
+            "X-Ops-Content-Hash:#{hashed_body(digest)}",
+            "X-Ops-Sign:version=#{sign_version}",
+            "X-Ops-Timestamp:#{canonical_time}",
+            "X-Ops-UserId:#{canonical_x_ops_user_id}",
+            "X-Ops-Server-API-Version:#{server_api_version}",
+          ].join("\n")
+        else
+          [
+            "Method:#{http_method.to_s.upcase}",
+            "Hashed Path:#{digester.hash_string(canonical_path, digest)}",
+            "X-Ops-Content-Hash:#{hashed_body(digest)}",
+            "X-Ops-Timestamp:#{canonical_time}",
+            "X-Ops-UserId:#{canonical_x_ops_user_id}",
+          ].join("\n")
+        end
+      end
+
+      def canonicalize_user_id(user_id, proto_version, digest = OpenSSL::Digest::SHA1)
+        case proto_version
+        when "1.1"
+          # and 1.2 if that ever gets implemented
+          digester.hash_string(user_id, digest)
+        else
+          # versions 1.0 and 1.3
+          user_id
+        end
+      end
+
+      # Parses signature version information, algorithm used, etc.
+      #
+      # ====Parameters
+      #
+      def parse_signing_description
+        parts = signing_description.strip.split(";").inject({}) do |memo, part|
+          field_name, field_value = part.split("=")
+          memo[field_name.to_sym] = field_value.strip
+          memo
+        end
+        Mixlib::Authentication.logger.debug "Parsed signing description: #{parts.inspect}"
+        parts
+      end
+
+      def digester
+        Mixlib::Authentication::Digester
+      end
+
+      # private
+      def do_sign(private_key, digest, sign_algorithm, sign_version)
+        string_to_sign = canonicalize_request(sign_algorithm, sign_version)
+        Mixlib::Authentication.logger.debug "String to sign: '#{string_to_sign}'"
+        case sign_version
+        when "1.3"
+          private_key.sign(digest.new, string_to_sign)
+        else
+          private_key.private_encrypt(string_to_sign)
+        end
+      end
+
+      private :canonical_time, :canonical_path, :parse_signing_description, :digester, :canonicalize_user_id
+
+    end
+
+    # === SigningObject
+    # A Struct-based value object that contains the necessary information to
+    # generate a request signature. `SignedHeaderAuth.signing_object()`
+    # provides a more convenient interface to the constructor.
+    SigningObject = Struct.new(:http_method, :path, :body, :host,
+                                     :timestamp, :user_id, :file, :proto_version,
+                                     :headers) do
+      include SignedHeaderAuth
+
+      def proto_version
+        (self[:proto_version] || SignedHeaderAuth::DEFAULT_PROTO_VERSION).to_s
+      end
+
+      def server_api_version
+        key = (self[:headers] || {}).keys.select do |k|
+          k.casecmp("x-ops-server-api-version") == 0
+        end.first
+        if key
+          self[:headers][key]
+        else
+          DEFAULT_SERVER_API_VERSION
+        end
+      end
+    end
+  end
+end

--- a/lib/automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication/version.rb
+++ b/lib/automate_liveness_agent/vendor/mixlib-authentication/lib/mixlib/authentication/version.rb
@@ -1,0 +1,20 @@
+# Copyright:: Copyright (c) 2010-2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Mixlib
+  module Authentication
+    VERSION = "1.4.1"
+  end
+end


### PR DESCRIPTION
This add's a rake task that will vendor a given version of
`mixlib-authentication` and will update and `require`'s to point at the
vendored version of the gem.

After https://github.com/chef/mixlib-authentication/pull/21 has been merged and released we'll want to run the rake task and add the vendored code to this change.