### PR TITLE
[CLOUD-326] Send a properly formatted Automate node ping

### DIFF
--- a/lib/automate_liveness_agent/api_client.rb
+++ b/lib/automate_liveness_agent/api_client.rb
@@ -158,13 +158,13 @@ module AutomateLivenessAgent
     end
 
     def parse_uri
-      @uri = URI(config.chef_server_url)
+      @uri = URI(config.data_collector_url)
       unless VALID_PROTOCOLS.include?(uri.scheme)
-        raise ConfigError, "Chef Server URL '#{config.chef_server_url}' is invalid: only 'http' and 'https' protocols are supported"
+        raise ConfigError, "Data Collector URL '#{config.data_collector_url}' is invalid: only 'http' and 'https' protocols are supported"
       end
       @uri
     rescue URI::InvalidURIError => e
-      raise ConfigError, "Chef Server URL '#{config.chef_server_url}' is malformed (#{e})"
+      raise ConfigError, "Data Collector URL '#{config.data_collector_url}' is malformed (#{e})"
     end
 
     def set_base_request_params

--- a/lib/automate_liveness_agent/config.rb
+++ b/lib/automate_liveness_agent/config.rb
@@ -9,22 +9,26 @@ module AutomateLivenessAgent
     DEFAULT_CONFIG_PATH = "/etc/chef/config.json".freeze
 
     MANDATORY_CONFIG_SETTINGS = %w{
-      chef_server_url
+      chef_server_fqdn
       client_key_path
       client_name
+      data_collector_url
+      entity_uuid
+      org_name
       unprivileged_uid
       unprivileged_gid
     }.freeze
 
     attr_reader :config_path
-
-    attr_reader :chef_server_url
+    attr_reader :chef_server_fqdn
+    attr_reader :client_key
     attr_reader :client_key_path
     attr_reader :client_name
+    attr_reader :data_collector_url
+    attr_reader :entity_uuid
+    attr_reader :org_name
     attr_reader :unprivileged_uid
     attr_reader :unprivileged_gid
-
-    attr_reader :client_key
 
     def self.load(config_path)
       c = new(config_path)
@@ -33,15 +37,16 @@ module AutomateLivenessAgent
     end
 
     def initialize(config_path)
-      @config_path = File.expand_path(config_path || DEFAULT_CONFIG_PATH, Dir.pwd)
-
-      @chef_server_url =  nil
-      @client_key_path =  nil
-      @client_name =      nil
-      @unprivileged_uid = nil
-      @unprivileged_gid = nil
-
-      @client_key = nil
+      @config_path        = File.expand_path(config_path || DEFAULT_CONFIG_PATH, Dir.pwd)
+      @chef_server_fqdn   = nil
+      @client_key         = nil
+      @client_key_path    = nil
+      @client_name        = nil
+      @data_collector_url = nil
+      @entity_uuid        = nil
+      @org_name           = nil
+      @unprivileged_uid   = nil
+      @unprivileged_gid   = nil
     end
 
     def load
@@ -75,11 +80,14 @@ module AutomateLivenessAgent
         raise ConfigError, "Config file '#{config_path}' is missing mandatory setting(s): '#{missing_settings.join("','")}'"
       end
 
-      @chef_server_url = config_data["chef_server_url"]
-      @client_key_path = config_data["client_key_path"]
-      @client_name = config_data["client_name"]
-      @unprivileged_uid = config_data["unprivileged_uid"]
-      @unprivileged_gid = config_data["unprivileged_gid"]
+      @chef_server_fqdn   = config_data["chef_server_fqdn"]
+      @client_key_path    = config_data["client_key_path"]
+      @client_name        = config_data["client_name"]
+      @data_collector_url = config_data["data_collector_url"]
+      @entity_uuid        = config_data["entity_uuid"]
+      @org_name           = config_data["org_name"]
+      @unprivileged_uid   = config_data["unprivileged_uid"]
+      @unprivileged_gid   = config_data["unprivileged_gid"]
 
       self
     end
@@ -109,4 +117,3 @@ module AutomateLivenessAgent
 
   end
 end
-

--- a/spec/automate_liveness_agent/api_client_spec.rb
+++ b/spec/automate_liveness_agent/api_client_spec.rb
@@ -6,15 +6,18 @@ RSpec.describe AutomateLivenessAgent::APIClient do
 
   let(:client_key_path) { fixture("config/example.pem") }
 
-  let(:chef_server_url) { "https://chef.example/organizations/default" }
+  let(:data_collector_url) { "https://chef.example/organizations/default/data-collector" }
 
   let(:config_data) do
     {
-      "chef_server_url"  => chef_server_url,
-      "client_key_path"  => client_key_path,
-      "client_name"      => "testnode.example.com",
-      "unprivileged_uid" => 100,
-      "unprivileged_gid" => 100,
+      "chef_server_fqdn"   => "chef.example",
+      "client_key_path"    => client_key_path,
+      "client_name"        => "testnode.example.com",
+      "data_collector_url" => data_collector_url,
+      "entity_uuid"        => "d4a509ca-bc15-422d-8a17-1f3903856bc4",
+      "org_name"           => "default",
+      "unprivileged_uid"   => 100,
+      "unprivileged_gid"   => 100,
     }
   end
 
@@ -41,13 +44,13 @@ RSpec.describe AutomateLivenessAgent::APIClient do
 
       it "sets the API service URI" do
         expect(api_client.uri).to be_a(URI::Generic)
-        expect(api_client.uri.to_s).to eq("https://chef.example/organizations/default")
+        expect(api_client.uri.to_s).to eq("https://chef.example/organizations/default/data-collector")
       end
 
       it "sets the base request params for auth" do
         expected = {
           http_method: "POST",
-          path: "/organizations/default",
+          path: "/organizations/default/data-collector",
           host: "chef.example:443",
           headers: described_class::BASE_HEADERS,
           user_id: "testnode.example.com",
@@ -85,12 +88,12 @@ RSpec.describe AutomateLivenessAgent::APIClient do
 
     end
 
-    context "when the Chef Server URL is not a valid URI" do
+    context "when the Data Collector URL is not a valid URI" do
 
-      let(:chef_server_url) { "Lobster Bisque" }
+      let(:data_collector_url) { "Lobster Bisque" }
 
-      it "raises a ConfigError"do
-        expected_message = "Chef Server URL 'Lobster Bisque' is malformed (bad URI(is not URI?): Lobster Bisque)"
+      it "raises a ConfigError" do
+        expected_message = "Data Collector URL 'Lobster Bisque' is malformed (bad URI(is not URI?): Lobster Bisque)"
         expect { api_client.load_and_verify_config }.
           to raise_error(AutomateLivenessAgent::ConfigError, expected_message)
       end
@@ -99,10 +102,10 @@ RSpec.describe AutomateLivenessAgent::APIClient do
 
     context "when the Chef Server URL is a valid URI with a bizzaro protocol" do
 
-      let(:chef_server_url) { "telnet://towel.blinkenlights.nl" }
+      let(:data_collector_url) { "telnet://towel.blinkenlights.nl" }
 
       it "raises a ConfigError" do
-        expected_message = "Chef Server URL 'telnet://towel.blinkenlights.nl' is invalid: only 'http' and 'https' protocols are supported"
+        expected_message = "Data Collector URL 'telnet://towel.blinkenlights.nl' is invalid: only 'http' and 'https' protocols are supported"
         expect { api_client.load_and_verify_config }.
           to raise_error(AutomateLivenessAgent::ConfigError, expected_message)
       end

--- a/spec/automate_liveness_agent/config_spec.rb
+++ b/spec/automate_liveness_agent/config_spec.rb
@@ -92,11 +92,14 @@ RSpec.describe AutomateLivenessAgent::Config do
 
       BASE_CONFIG_DATA =
         {
-          "chef_server_url"  => "https://chef.example/organizations/default",
-          "client_key_path"  => "/etc/chef/client.pem",
-          "client_name"      => "testnode.example.com",
-          "unprivileged_uid" => 100,
-          "unprivileged_gid" => 100,
+          "chef_server_fqdn"   => "chef.example",
+          "client_key_path"    => "/etc/chef/client.pem",
+          "client_name"        => "testnode.example.com",
+          "data_collector_url" => "https://chef.example/organizations/default/data-collector",
+          "entity_uuid"        => "d4a509ca-bc15-422d-8a17-1f3903856bc4",
+          "org_name"           => "default",
+          "unprivileged_uid"   => 100,
+          "unprivileged_gid"   => 100,
         }
 
       BASE_CONFIG_DATA.each_key do |key|
@@ -119,8 +122,8 @@ RSpec.describe AutomateLivenessAgent::Config do
         let(:config_data) { {} }
 
         let(:expected_message) do
-          "Config file '#{config_path}' is missing mandatory setting(s): "\
-            "'chef_server_url','client_key_path','client_name','unprivileged_uid','unprivileged_gid'"
+          "Config file '#{config_path}' is missing mandatory setting(s): " <<
+            BASE_CONFIG_DATA.keys.map { |k| "'#{k}'" }.join(",")
         end
 
         it "raises a ConfigError" do
@@ -141,16 +144,24 @@ RSpec.describe AutomateLivenessAgent::Config do
       config.load_config_file
     end
 
-    it "has a Chef Server URL" do
-      expect(config.chef_server_url).to eq("https://chef.example/organizations/default")
-    end
-
     it "has a client key path" do
       expect(config.client_key_path).to eq("/etc/chef/client.pem")
     end
 
     it "has a client name" do
       expect(config.client_name).to eq("testnode.example.com")
+    end
+
+    it "has a Chef Server FQDN" do
+      expect(config.chef_server_fqdn).to eq("chef.example")
+    end
+
+    it "has a Data Collector URL" do
+      expect(config.data_collector_url).to eq("https://chef.example/organizations/default/data-collector")
+    end
+
+    it "has an org name" do
+      expect(config.org_name).to eq("default")
     end
 
     it "has a UID to drop privileges to" do
@@ -165,14 +176,16 @@ RSpec.describe AutomateLivenessAgent::Config do
 
   describe "loading the client key" do
 
-
     let(:config_data) do
       {
-        "chef_server_url"  => "https://chef.example/organizations/default",
-        "client_key_path"  => client_key_path,
-        "client_name"      => "testnode.example.com",
-        "unprivileged_uid" => 100,
-        "unprivileged_gid" => 100,
+        "client_key_path"    => client_key_path,
+        "client_name"        => "testnode.example.com",
+        "chef_server_fqdn"   => "chef.example",
+        "data_collector_url" => "https://chef.example/organizations/default/data-collector",
+        "org_name"           => "deafault",
+        "entity_uuid"        => "d4a509ca-bc15-422d-8a17-1f3903856bc4",
+        "unprivileged_uid"   => 100,
+        "unprivileged_gid"   => 100,
       }
     end
 
@@ -208,4 +221,3 @@ RSpec.describe AutomateLivenessAgent::Config do
 
   end
 end
-

--- a/spec/automate_liveness_agent/liveness_update_sender_spec.rb
+++ b/spec/automate_liveness_agent/liveness_update_sender_spec.rb
@@ -1,0 +1,45 @@
+require "automate_liveness_agent/liveness_update_sender"
+
+RSpec.describe AutomateLivenessAgent::LivenessUpdateSender do
+  let(:config) do
+    AutomateLivenessAgent::Config.new("/etc/chef/agent.json").load_data(
+      {
+        "client_key_path"    => fixture("config/example.pem"),
+        "client_name"        => "testnode.example.com",
+        "chef_server_fqdn"   => "chef.example",
+        "data_collector_url" => "https://chef.example/organizations/default/data-collector",
+        "org_name"           => "default",
+        "unprivileged_uid"   => 100,
+        "unprivileged_gid"   => 100,
+        "entity_uuid"        => "d4a509ca-bc15-422d-8a17-1f3903856bc4",
+      }
+    )
+  end
+
+  let(:time) { Time.now }
+
+  before do
+    allow(Time).to receive(:now).and_return(time)
+  end
+
+  subject { described_class.new(config) }
+
+  describe "#update" do
+    it "sends a valid payload" do
+      expect(subject.api_client).to receive(:request).with(
+        {
+          "chef_server_fqdn" => "chef.example",
+          "source" => "liveness_agent",
+          "message_version" => "0.0.1",
+          "message_type" => "node_ping",
+          "organization_name" => "default",
+          "node_name" => "testnode.example.com",
+          "entity_uuid" => "d4a509ca-bc15-422d-8a17-1f3903856bc4",
+          "@timestamp" => time.utc.iso8601,
+        }.to_json
+      )
+
+      subject.update
+    end
+  end
+end

--- a/spec/fixtures/config/valid_config.json
+++ b/spec/fixtures/config/valid_config.json
@@ -1,7 +1,10 @@
 {
-  "chef_server_url": "https://chef.example/organizations/default",
-  "client_key_path":  "/etc/chef/client.pem",
-  "client_name":      "testnode.example.com",
+  "client_key_path": "/etc/chef/client.pem",
+  "client_name": "testnode.example.com",
+  "chef_server_fqdn": "chef.example",
+  "data_collector_url": "https://chef.example/organizations/default/data-collector",
+  "org_name": "default",
+  "entity_uuid": "d4a509ca-bc15-422d-8a17-1f3903856bc4",
   "unprivileged_uid": 100,
   "unprivileged_gid": 200
 }


### PR DESCRIPTION
Make the update sender POST a valid `node_ping` payload to the Chef
Automate data collector instead of the Chef Server URL.

```json
{
  "chef_server_fqdn": "chef-server.opsworks.com",
  "source": "liveness_agent",
  "message_version": "0.0.1",
  "message_type": "node_ping",
  "organization_name": "happytrees",
  "node_name": "leaf",
  "entity_uuid": "d4a509ca-bc15-422d-8a17-1f3903856bc4",
  "@timestamp": "2017-04-21T22:59:00Z"
}
```