### PR TITLE
Productionize Logging (CLOUD-321)

### DIFF
--- a/lib/automate_liveness_agent/api_client.rb
+++ b/lib/automate_liveness_agent/api_client.rb
@@ -36,13 +36,15 @@ module AutomateLivenessAgent
     HTTPS_SCHEME = "https".freeze
 
     attr_reader :config
+    attr_reader :logger
     attr_reader :uri
     attr_reader :base_request_params
     attr_reader :private_key
     attr_reader :http
 
-    def initialize(config)
+    def initialize(config, logger)
       @config = config
+      @logger = logger
     end
 
     def load_and_verify_config
@@ -88,13 +90,8 @@ module AutomateLivenessAgent
 
     private
 
-    # TODO: figure out logging requirements:
-    # * Are we logging to files and responsible for rotating them?
-    # * Can we _just_ log to a stream (like stdout)?
-    # * Do we need to deal with the stream closing and reopening and all that jazz?
-    # * in debug mode (ENV["DEBUG"]) are we sending output to that stream? (rn, $stderr is hardcoded)
     def log(message)
-      $stdout.print("#{message}\n")
+      logger.info(message)
     end
 
     def request_without_retries(body)

--- a/lib/automate_liveness_agent/config.rb
+++ b/lib/automate_liveness_agent/config.rb
@@ -220,7 +220,7 @@ module AutomateLivenessAgent
 
     def validate_log_path(log_path)
       log_dir = File.dirname(log_path)
-      unless File.exist?(log_dir) && File.directory?(log_dir)
+      unless File.directory?(log_dir)
         raise ConfigError, "Log directory '#{log_dir}' (inferred from log_path config) does not exist or is not a directory"
       end
       unless File.writable?(log_dir)

--- a/lib/automate_liveness_agent/config.rb
+++ b/lib/automate_liveness_agent/config.rb
@@ -89,7 +89,7 @@ module AutomateLivenessAgent
     def apply_config_values(config_data)
       missing_settings = MANDATORY_CONFIG_SETTINGS - config_data.keys
       unless missing_settings.empty?
-        raise ConfigError, "Config file '#{config_path}' is missing mandatory setting(s): '#{missing_settings.join("','")}'"
+        raise ConfigError, "Config file '#{config_path}' is missing mandatory setting(s): \"#{missing_settings.join('","')}\""
       end
 
       # Mandatory config

--- a/lib/automate_liveness_agent/config.rb
+++ b/lib/automate_liveness_agent/config.rb
@@ -93,6 +93,9 @@ module AutomateLivenessAgent
       apply_config_values(config_data)
     end
 
+    # The logger should only be setup after privileges are dropped. Otherwise
+    # you can get into a situation where you've created the logfile as root,
+    # but no longer have root privileges and are not allowed to rotate the logfile
     def setup_logger
       @logger ||= Logger.new(validate_and_normalize_log_path(log_file), 1, logfile_max_size)
     end

--- a/lib/automate_liveness_agent/liveness_update_sender.rb
+++ b/lib/automate_liveness_agent/liveness_update_sender.rb
@@ -6,19 +6,21 @@ module AutomateLivenessAgent
   class LivenessUpdateSender
 
     attr_reader :config
+    attr_reader :logger
     attr_reader :api_client
 
     UPDATE_INTERVAL_S = 60 * 30
 
-    def initialize(config)
+    def initialize(config, logger)
       @config = config
+      @logger = logger
 
-      @api_client = APIClient.new(config)
+      @api_client = APIClient.new(config, logger)
       api_client.load_and_verify_config
     end
 
     def log(message)
-      print("#{message}\n")
+      logger.info(message)
     end
 
     def main_loop

--- a/lib/automate_liveness_agent/main.rb
+++ b/lib/automate_liveness_agent/main.rb
@@ -37,6 +37,7 @@ module AutomateLivenessAgent
     attr_reader :argv
     attr_reader :config_path
     attr_reader :config
+    attr_reader :logger
 
     def self.run(argv)
       new(argv).run
@@ -46,6 +47,7 @@ module AutomateLivenessAgent
       @argv = argv
       @config_path = nil
       @config = Config.new(nil)
+      @logger = nil
     end
 
     def run
@@ -53,6 +55,7 @@ module AutomateLivenessAgent
         run(:handle_argv).
         run(:load_config).
         run(:set_privileges).
+        run(:setup_logger).
         run(:send_keepalives).
         finish
     end
@@ -93,8 +96,15 @@ module AutomateLivenessAgent
       [ 1,  msg ]
     end
 
+    def setup_logger
+      @logger = config.setup_logger
+      SUCCESS
+    rescue ConfigError => e
+      [ 1, e.to_s ]
+    end
+
     def send_keepalives
-      a = LivenessUpdateSender.new(config)
+      a = LivenessUpdateSender.new(config, logger)
       a.main_loop
       SUCCESS
     rescue ConfigError => e

--- a/lib/automate_liveness_agent/main.rb
+++ b/lib/automate_liveness_agent/main.rb
@@ -96,6 +96,9 @@ module AutomateLivenessAgent
       [ 1,  msg ]
     end
 
+    # This intentionally comes after #set_privileges. Depending on config and
+    # system state, the logger may create logfiles; we must create the files as
+    # the lower privileged user or else we won't have permissions to rotate them.
     def setup_logger
       @logger = config.setup_logger
       SUCCESS

--- a/spec/automate_liveness_agent/api_client_spec.rb
+++ b/spec/automate_liveness_agent/api_client_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe AutomateLivenessAgent::APIClient do
 
   let(:config) { AutomateLivenessAgent::Config.new(config_path).load_data(config_data) }
 
-  let(:api_client) { described_class.new(config) }
+  let(:api_client) { described_class.new(config, Logger.new(nil)) }
 
   it "is created with a config object" do
     expect(api_client.config).to eq(config)

--- a/spec/automate_liveness_agent/config_spec.rb
+++ b/spec/automate_liveness_agent/config_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe AutomateLivenessAgent::Config do
 
           let(:config_data) { BASE_CONFIG_DATA.dup.tap { |d| d.delete(key) } }
 
-          let(:expected_message) { "Config file '#{config_path}' is missing mandatory setting(s): '#{key}'" }
+          let(:expected_message) { "Config file '#{config_path}' is missing mandatory setting(s): \"#{key}\"" }
 
           it "raises a ConfigError" do
             expect { config.apply_config_values(config_data) }.
@@ -121,7 +121,7 @@ RSpec.describe AutomateLivenessAgent::Config do
 
         let(:expected_message) do
           "Config file '#{config_path}' is missing mandatory setting(s): " <<
-            BASE_CONFIG_DATA.keys.map { |k| "'#{k}'" }.join(",")
+            BASE_CONFIG_DATA.keys.map { |k| "\"#{k}\"" }.join(',')
         end
 
         it "raises a ConfigError" do

--- a/spec/automate_liveness_agent/config_spec.rb
+++ b/spec/automate_liveness_agent/config_spec.rb
@@ -213,7 +213,6 @@ RSpec.describe AutomateLivenessAgent::Config do
         let(:configured_log_file) { fixture("logger/logs") }
 
         it "fails with a config error" do
-          expect(File).to receive(:exist?).with(fixture("logger")).and_return(true)
           expect(File).to receive(:writable?).with(fixture("logger")).and_return(true)
           expect(File).to receive(:exist?).with(fixture("logger/logs")).and_return(true)
           expect(File).to receive(:writable?).with(fixture("logger/logs")).and_return(false)

--- a/spec/automate_liveness_agent/config_spec.rb
+++ b/spec/automate_liveness_agent/config_spec.rb
@@ -1,5 +1,17 @@
 RSpec.describe AutomateLivenessAgent::Config do
 
+  BASE_CONFIG_DATA =
+    {
+    "chef_server_fqdn"   => "chef.example",
+    "client_key_path"    => fixture("config/example.pem"),
+    "client_name"        => "testnode.example.com",
+    "data_collector_url" => "https://chef.example/organizations/default/data-collector",
+    "entity_uuid"        => "d4a509ca-bc15-422d-8a17-1f3903856bc4",
+    "org_name"           => "default",
+    "unprivileged_uid"   => 100,
+    "unprivileged_gid"   => 100,
+  }
+
   let(:config_path) { "/path/to/config.json" }
 
   subject(:config) { described_class.new(config_path) }
@@ -88,18 +100,6 @@ RSpec.describe AutomateLivenessAgent::Config do
 
     describe "when the config file doesn't contain all required values" do
 
-      BASE_CONFIG_DATA =
-        {
-          "chef_server_fqdn"   => "chef.example",
-          "client_key_path"    => "/etc/chef/client.pem",
-          "client_name"        => "testnode.example.com",
-          "data_collector_url" => "https://chef.example/organizations/default/data-collector",
-          "entity_uuid"        => "d4a509ca-bc15-422d-8a17-1f3903856bc4",
-          "org_name"           => "default",
-          "unprivileged_uid"   => 100,
-          "unprivileged_gid"   => 100,
-        }
-
       BASE_CONFIG_DATA.each_key do |key|
 
         context "when key '#{key}' is not present" do
@@ -132,6 +132,135 @@ RSpec.describe AutomateLivenessAgent::Config do
 
     end
 
+  end
+
+  describe "configuring the logger" do
+
+    let(:logger) { config.setup_logger }
+
+    let(:log_dev) { logger.instance_variable_get(:@logdev) }
+
+    let(:log_io) { log_dev.dev }
+
+    let(:configured_log_file) { nil }
+
+    let(:config_data) do
+      BASE_CONFIG_DATA.merge("log_file" => configured_log_file)
+    end
+
+    before do
+      config.load_data(config_data)
+    end
+
+    context "when not set or set to nil" do
+
+      it "logs to stdout" do
+        expect(logger).to be_a_kind_of(Logger)
+        expect(log_io).to eq(STDOUT)
+      end
+
+    end
+
+    context "when set to STDOUT" do
+
+      let(:configured_log_file) { "STDOUT" }
+
+      it "logs to stdout" do
+        expect(logger).to be_a_kind_of(Logger)
+        expect(log_io).to eq(STDOUT)
+      end
+
+    end
+
+    context "when set to STDERR" do
+
+      let(:configured_log_file) { "STDERR" }
+
+      it "logs to stderr" do
+        expect(logger).to be_a_kind_of(Logger)
+        expect(log_io).to eq(STDERR)
+      end
+
+    end
+
+    context "when set to a file" do
+
+      context "when the file's directory doesn't exist" do
+
+        let(:configured_log_file) { fixture("no_such_path/exists/log") }
+
+        it "fails with a config error" do
+          message = "Log directory '#{fixture("no_such_path/exists")}' (inferred from log_path config) does not exist or is not a directory"
+          expect { config.setup_logger }.to raise_error(AutomateLivenessAgent::ConfigError, message)
+        end
+
+      end
+
+      context "when the file's directory isn't writable" do
+
+        let(:configured_log_file) { fixture("logger/logs") }
+
+        it "fails with a config error" do
+          expect(File).to receive(:writable?).with(fixture("logger")).and_return(false)
+          message = "Log directory '#{fixture("logger")}' (inferred from log_path config) is not writable by current user (uid: #{Process.uid})"
+          expect { config.setup_logger }.to raise_error(AutomateLivenessAgent::ConfigError, message)
+        end
+
+      end
+
+      context "when the log file itself exists and isn't writable" do
+
+        let(:configured_log_file) { fixture("logger/logs") }
+
+        it "fails with a config error" do
+          expect(File).to receive(:exist?).with(fixture("logger")).and_return(true)
+          expect(File).to receive(:writable?).with(fixture("logger")).and_return(true)
+          expect(File).to receive(:exist?).with(fixture("logger/logs")).and_return(true)
+          expect(File).to receive(:writable?).with(fixture("logger/logs")).and_return(false)
+          message = "Log file '#{fixture("logger/logs")}' (set by log_path config) is not writable by current user (uid: #{Process.uid})"
+          expect { config.setup_logger }.to raise_error(AutomateLivenessAgent::ConfigError, message)
+        end
+
+      end
+
+      context "when the file permissions are all ok" do
+
+        def nuke_files
+          Dir[fixture("logger/*")].each { |f| File.unlink(f) }
+        end
+
+        let(:configured_log_file) { fixture("logger/logs") }
+
+        let(:max_size) { log_dev.instance_variable_get(:@shift_size) }
+
+        before { nuke_files }
+        after { nuke_files }
+
+        context "without stress mode" do
+
+          it "opens the log and configures a max size of 512k and 2 files to rotate" do
+            expect(log_io.path).to eq(configured_log_file)
+            expect(max_size).to eq(512 * 1024)
+          end
+
+        end
+
+        context "when stress mode is enabled" do
+
+          around do |e|
+            ENV["LOGGER_STRESS_MODE"] = "1"
+            e.run
+            ENV.delete("LOGGER_STRESS_MODE")
+          end
+
+          it "configures a max size of 2k" do
+            expect(log_io.path).to eq(configured_log_file)
+            expect(max_size).to eq(2 * 1024)
+          end
+
+        end
+      end
+    end
   end
 
   context "after the config file is loaded" do

--- a/spec/automate_liveness_agent/liveness_update_sender_spec.rb
+++ b/spec/automate_liveness_agent/liveness_update_sender_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe AutomateLivenessAgent::LivenessUpdateSender do
     allow(Time).to receive(:now).and_return(time)
   end
 
-  subject(:update_sender) { described_class.new(config) }
+  subject(:update_sender) { described_class.new(config, Logger.new(nil)) }
 
   describe "#update" do
     it "sends a valid payload" do

--- a/spec/automate_liveness_agent/main_spec.rb
+++ b/spec/automate_liveness_agent/main_spec.rb
@@ -149,11 +149,13 @@ RSpec.describe AutomateLivenessAgent::Main do
 
     let(:update_sender) { instance_double("AutomateLivenessAgent::LivenessUpdateSender") }
 
+    before { application.setup_logger }
+
     context "with a valid configuration" do
 
       it "runs the update sender's main loop" do
         expect(AutomateLivenessAgent::LivenessUpdateSender).to receive(:new).
-          with(application.config).
+          with(application.config, application.logger).
           and_return(update_sender)
         expect(update_sender).to receive(:main_loop)
         expect(application.send_keepalives).to eq(described_class::SUCCESS)
@@ -165,7 +167,7 @@ RSpec.describe AutomateLivenessAgent::Main do
 
       it "exits 1 with the error message" do
         expect(AutomateLivenessAgent::LivenessUpdateSender).to receive(:new).
-          with(application.config).
+          with(application.config, application.logger).
           and_return(update_sender)
         expect(update_sender).to receive(:main_loop).
           and_raise(AutomateLivenessAgent::ConfigError, "explanation of problem")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,6 +74,7 @@ end
 
 module AutomateLivenessAgent
   module TestHelpers
+
     FIXTURES_DIR = File.expand_path("../fixtures/", __FILE__)
 
     def fixture(name)
@@ -170,5 +171,6 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 
   config.include AutomateLivenessAgent::TestHelpers
+  config.extend AutomateLivenessAgent::TestHelpers
 end
 


### PR DESCRIPTION
Uses the ruby logger since that is able to rotate logs on its own. By default it just keeps 2 files, each with a max of 512K. When all requests are failing, we emit about 1.5K of logs per cycle, so that's about 340 cycles or 7 days worth. In the success case, logs are under 1/2K.

There is also a stress mode which sets the log size to 2K, in combination with the `INTERVAL` setting, this can be used to make the logs roll over more quickly so we can ensure that log rotation is working.