### PR TITLE
 Win 2016 support     

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -794,8 +794,4 @@ suites:
       inspec_tests:
         - test/integration/unsupported-platform
     includes:
-      - solaris-10.11
-      - solaris-10.11-12
-      - solaris-11.3
-      - solaris-11.3-12
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -281,7 +281,7 @@ platforms:
           org_name: windows2008r2c12
     verifier:
       attributes:
-        org_name: windows2008r2
+        org_name: windows2008r2c12
         kitchen_dir: C:\\Users\\vagrant\\AppData\\Local\\Temp\\kitchen\\
         windows: true
         sleep_seconds: 100
@@ -309,7 +309,7 @@ platforms:
           org_name: windows2012r2c12
     verifier:
       attributes:
-        org_name: windows2012r2
+        org_name: windows2012r2c12
         kitchen_dir: C:\\Users\\vagrant\\AppData\\Local\\Temp\\kitchen\\
         windows: true
         sleep_seconds: 100
@@ -338,7 +338,7 @@ platforms:
           org_name: windows2016c12
     verifier:
       attributes:
-        org_name: windows2016
+        org_name: windows2016c12
         kitchen_dir: C:\\Users\\vagrant\\AppData\\Local\\Temp\\kitchen\\
         windows: true
         sleep_seconds: 100
@@ -750,10 +750,12 @@ suites:
       - centos-7.3-12
       - amazon-linux
       - amazon-linux-12
-      - windows-2008-standard-13
       - windows-2008-standard-12
-      - windows-2012-standard-13
+      - windows-2008-standard-13
       - windows-2012-standard-12
+      - windows-2012-standard-13
+      - windows-2016-standard-12
+      - windows-2016-standard-13
       # secondary platforms
       - freebsd-10.3
       - freebsd-10.3-12
@@ -792,5 +794,8 @@ suites:
       inspec_tests:
         - test/integration/unsupported-platform
     includes:
-      - windows-2016-standard-13
-      - windows-2016-standard-12
+      - solaris-10.11
+      - solaris-10.11-12
+      - solaris-11.3
+      - solaris-11.3-12
+

--- a/lib/automate_liveness_agent/api_client.rb
+++ b/lib/automate_liveness_agent/api_client.rb
@@ -103,7 +103,7 @@ module AutomateLivenessAgent
     end
 
     def log_response(status, response)
-      log("HTTP Request finished (#{status}): #{response.code} #{response.message}")
+      log("HTTP Request to #{uri} finished (#{status}): #{response.code} #{response.message}")
       log("Response body: #{response.body}")
     end
 

--- a/lib/recipe.rb
+++ b/lib/recipe.rb
@@ -28,12 +28,8 @@ return unless %w(
   windows
 ).include?(node['platform_family'])
 
-# windows 10 and greater not supported yet; improve this somehow
-return if platform?('windows') && node['platform_version'] =~ /^1[0-9]\./
-
 # only support solaris 10 and 11
 return if platform?('solaris2') && node['platform_version'] !~ /^5.(10|11)$/
-
 liveness_agent = <<'AUTOMATE_LIVENESS_AGENT'
 #LIVENESS_AGENT
 AUTOMATE_LIVENESS_AGENT
@@ -107,7 +103,7 @@ admin_group = value_for_platform_family(
     mac_os_x
   )            => 'wheel',
   %i(solaris2) => 'sys',
-  %i(windows)  => 'administrator'
+  %i(windows)  => 'Administrators'
 )
 agent_user_shell = value_for_platform_family(
   %i(
@@ -201,7 +197,7 @@ SCRIPT_BODY
   powershell_script 'Setup scheduled task' do
     # If we are running powershell > 3, there's a nice API to do this, but 2008r2 doesn't provide that
     code <<-EOH
-schtasks /create /f /sc minute /mo #{run_interval} /tn "Chef Liveness Agent" /tr "powershell.exe -windowstyle hidden #{scheduled_task_script}"
+schtasks /create /f /sc minute /mo #{run_interval} /tn "Chef Liveness Agent" /ru SYSTEM /rl HIGHEST /tr "powershell.exe -windowstyle hidden #{scheduled_task_script}"
 EOH
   end
 


### PR DESCRIPTION
Windows server versions later than 2008 have stricter requirements on scheduled tasks, and can  fail to run if the owning user of the task isn't logged in. This uses the SYSTEM user as the owner of the task.
