### PR TITLE
Cloud 373/idempotent cookbook

### DIFF
--- a/lib/compile_to_file/app.rb
+++ b/lib/compile_to_file/app.rb
@@ -41,6 +41,7 @@ module CompileToFile
       File.open(output_file, "w+") do |compiled|
 
         compiled << shebang
+        compiled << "# Compiled at #{Time.now}\n"
 
         @files.each do |source_file|
           compiled << source_file.processed_source


### PR DESCRIPTION
The task creation process ran the command every time, causing the
chef-client run to always report changes. Added code to check the
existing state and skip running the command.

The windows_user resource isn't idempotent. We don't use the user in
windows anyway, so suppressed creating the user in that case.