### PR TITLE
Cloud 373/not so chatty

### DIFF
--- a/test/integration/supported-platform/controls/supported-platform.rb
+++ b/test/integration/supported-platform/controls/supported-platform.rb
@@ -13,7 +13,7 @@ sleep_cmd     = "sleep #{sleep_seconds}"
 log_file_path = "/var/log/chef/automate-liveness-agent/automate-liveness-agent.log"
 client_cmd    =
   if windows
-    "chef-client -z -c #{client_rb} -j #{client_attrs}"
+    "$env:CHEF_RUN_INTERVAL=1 ; chef-client -z -c #{client_rb} -j #{client_attrs}"
   else
     "INTERVAL=2 chef-client -z -c #{client_rb} -j #{client_attrs}"
   end


### PR DESCRIPTION
Split into separate pieces for easier review; merge after #42 lands. 


    Make the windows scheduled task run interval 30 minutes. This took
    some extra work, as we had to:
    
    1) Make the tests pass, even though they need a 1 minute or so run
       interval to work properly.  This was done by adding an extra
       environment variable to override the default 30 minute interval.
    
    2) Fix a lingering issue from the idempotence work not updating the
       scheduled task when the interval changed.  Windows doesn't provide
       the timing data in a easily parsable form, which makes it hard to
       compare the current interval with the desired one. Changed
       intervals wouldn't propagate, and so even when we changed that, the
       task wouldn't update. Added a dummy interval value to the command
       line to make it possible to detect changes.
    
