### PR TITLE
Only append compilation timestamp in debug mode

### DIFF
--- a/lib/compile_to_file/app.rb
+++ b/lib/compile_to_file/app.rb
@@ -41,7 +41,7 @@ module CompileToFile
       File.open(output_file, "w+") do |compiled|
 
         compiled << shebang
-        compiled << "# Compiled at #{Time.now}\n"
+        compiled << "# Compiled at #{Time.now}\n" if ENV['DEBUG']
 
         @files.each do |source_file|
           compiled << source_file.processed_source


### PR DESCRIPTION
By vendoring a timestamp into the liveness agent every time we compile
it we're changing the contents unnecessarily. This has the effect of
causing us to rewrite the file and restart the liveness agent service on
all machines in the fleet for every recipe release. This change allows
us to compile the timestamp during development or debug but ommits it
when building a release artifact.