### PR TITLE
[CLOUD-346] Add upgrade testing to integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /build/*
 */.kitchen/*
 /test/cookbooks/liveness-agent-test/recipes/compiled-recipe.rb
+/test/cookbooks/liveness-agent-test/recipes/stable-compiled-recipe.rb

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ bundle exec rspec
 To test the compiled recipe on a target platform:
 
 ```
-rake compile_recipe
+rake compile_recipe vendor_stable_recipe
 kitchen converge required-faux-chef-automate
 kitchen test $target-platform
 ```

--- a/RELEASE_PLAN.md
+++ b/RELEASE_PLAN.md
@@ -12,26 +12,13 @@ TEST_BUILD_ARTIFACT=1 bundle exec rake
 
 #### Kitchen Acceptance Tests
 
-Run the full kitchen acceptance suite
+Run the full kitchen acceptance suite to verify recipe upgrade, convergence,
+re-convergence, and liveness agent logging and pings.
 
 ```
 rake compile_recipe
 kitchen converge automate
 kitchen test supported
-```
-
-#### Recipe and Init Script Testing
-
-##### Recipe Multi-Run Test
-
-Run this recipe at least 2x so we know it works continuously. This is tested
-during the integration suite.
-
-```
-kitchen test PLATFORM -d never
-kitchen login PLATFORM
-sudo -i
-INTERVAL=2 chef-client -z -c /tmp/kitchen/test-client.rb -j /tmp/kitchen/test-attrs.json
 ```
 
 ##### Init Script Acceptance Test

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ require "rspec/core/rake_task"
 Dir["tasks/*"].each { |t| load t }
 
 task :default => :travis
+
 task :spec => :compile
 RSpec::Core::RakeTask.new(:spec)
 

--- a/tasks/vendor_stable_recipe.rb
+++ b/tasks/vendor_stable_recipe.rb
@@ -1,0 +1,36 @@
+require "net/http"
+require "json"
+
+def http_get(uri)
+  @uri = uri
+
+  5.times do
+    uri = URI(@uri)
+    req = Net::HTTP::Get.new(uri)
+    res = Net::HTTP.start( uri.host, uri.port, use_ssl: uri.scheme == "https") do |http|
+      http.request(req)
+    end
+
+    case res
+    when Net::HTTPSuccess
+      return res
+    when Net::HTTPRedirection
+      @uri = res["location"]
+    else
+      res.error!
+    end
+  end
+end
+
+desc "Vendor latest stable recipe"
+task :vendor_stable_recipe do
+  res = http_get("https://api.github.com/repos/chef/automate-liveness-agent/releases/latest")
+
+  url = JSON.parse(res.body)["assets"].find do |a|
+    a["name"] == "automate-liveness-recipe.rb"
+  end["browser_download_url"]
+
+  File.open("./test/cookbooks/liveness-agent-test/recipes/stable-compiled-recipe.rb", "w+") do |f|
+    f.write(http_get(url).body)
+  end
+end

--- a/test/cookbooks/liveness-agent-test/recipes/test-client.rb
+++ b/test/cookbooks/liveness-agent-test/recipes/test-client.rb
@@ -15,12 +15,20 @@ file ::File.join(kitchen_root, 'test-client.rb') do
   content client_content
 end
 
-# Create an client attributes file that'll run our compiled recipe
-attrs = Chef::JSONCompat.parse(::File.read(::File.join(kitchen_root, 'dna.json')))
-attrs['run_list'] = ['recipe[liveness-agent-test::compiled-recipe]']
+# Create an client attributes files so we can test our stable recipe and our
+# current recipe.
+current_attrs = Chef::JSONCompat.parse(::File.read(::File.join(kitchen_root, 'dna.json')))
+stable_attrs = current_attrs.dup
 
-file ::File.join(kitchen_root, 'test-attrs.json') do
-  content Chef::JSONCompat.to_json_pretty(attrs)
+current_attrs['run_list'] = ['recipe[liveness-agent-test::compiled-recipe]']
+stable_attrs['run_list'] = ['recipe[liveness-agent-test::stable-compiled-recipe]']
+
+file ::File.join(kitchen_root, 'test-stable-attrs.json') do
+  content Chef::JSONCompat.to_json_pretty(stable_attrs)
+end
+
+file ::File.join(kitchen_root, 'test-current-attrs.json') do
+  content Chef::JSONCompat.to_json_pretty(current_attrs)
 end
 
 # Make sure that /var/log/chef exists and is writable by the vagrant user. If


### PR DESCRIPTION
* Update RELEASE_PLAN.md
* Update README.md
* Add rake task for vendoring the latest stable liveness agent recipe
* Converge the stable recipe before the latest compiled recipe to test
  upgrades.