### PR TITLE
Allow setting config interval and reading from env

### DIFF
--- a/lib/automate_liveness_agent/config.rb
+++ b/lib/automate_liveness_agent/config.rb
@@ -48,6 +48,7 @@ module AutomateLivenessAgent
     attr_reader :install_check_file
     attr_reader :log_file
     attr_reader :scheduled_task_mode
+    attr_reader :interval
 
     def self.load(config_path)
       c = new(config_path)
@@ -78,6 +79,7 @@ module AutomateLivenessAgent
       @install_check_file   = nil
       @log_file             = nil
       @scheduled_task_mode  = false
+      @interval             = nil
     end
 
     def load
@@ -149,6 +151,10 @@ module AutomateLivenessAgent
         sanity_check_daemon_mode(config_data["daemon_mode"])
       end
 
+      if config_data.key?("interval")
+        sanity_check_interval(config_data["interval"])
+      end
+
       @install_check_file   = config_data["install_check_file"]
       @log_file             = config_data["log_file"]
       @scheduled_task_mode  = config_data["scheduled_task_mode"]
@@ -217,6 +223,22 @@ module AutomateLivenessAgent
 
     def sanity_check_daemon_mode(mode)
       @daemon_mode = mode.is_a?(TrueClass) || mode == "true" ? true : false
+    end
+
+    def sanity_check_interval(seconds)
+      if seconds.is_a?(Integer)
+        @interval = seconds
+      elsif seconds.is_a?(String)
+        if seconds.scan(/\D/).empty?
+          @interval = seconds.to_i
+        else
+          raise ConfigError, "interval '#{seconds}' is not an integer"
+        end
+      elsif seconds.nil?
+        @interval = nil
+      else
+        raise ConfigError, "interval '#{seconds}' is not an integer"
+      end
     end
 
     def validate_and_normalize_log_path(log_path)

--- a/lib/automate_liveness_agent/liveness_update_sender.rb
+++ b/lib/automate_liveness_agent/liveness_update_sender.rb
@@ -28,7 +28,7 @@ module AutomateLivenessAgent
       obj_counts = {}
       log("PROCESS ID: #{Process.pid}")
 
-      interval = (ENV["INTERVAL"] || UPDATE_INTERVAL_S).to_i
+      interval = (ENV["INTERVAL"] || config.interval || UPDATE_INTERVAL_S).to_i
       loop do
         if chef_uninstalled?
           log("Chef Client appears to have been uninstalled, shutting down")

--- a/lib/recipe.rb
+++ b/lib/recipe.rb
@@ -52,6 +52,7 @@ run_interval      = ENV['CHEF_RUN_INTERVAL'] || 30 # (only windows), to ease tes
 server_uri        = URI(Chef::Config[:chef_server_url])
 trusted_certs_dir = File.directory?(Chef::Config[:trusted_certs_dir]) ? Chef::Config[:trusted_certs_dir] : nil
 daemon_mode       = platform?('windows') || platform?('aix') ? false : true
+interval          = ENV['INTERVAL']
 
 agent_service_name = value_for_platform_family(
   %i(
@@ -181,7 +182,8 @@ file agent_conf do
         'ssl_ca_file'         => Chef::Config[:ssl_ca_file],
         'ssl_ca_path'         => Chef::Config[:ssl_ca_path],
         'trusted_certs_dir'   => trusted_certs_dir,
-        'scheduled_task_mode' => platform?('windows') || platform?('mac_os_x')
+        'scheduled_task_mode' => platform?('windows') || platform?('mac_os_x'),
+        'interval'            => interval
       )
     end
   )

--- a/spec/automate_liveness_agent/config_spec.rb
+++ b/spec/automate_liveness_agent/config_spec.rb
@@ -355,4 +355,58 @@ RSpec.describe AutomateLivenessAgent::Config do
     end
 
   end
+
+  describe "setting the interval" do
+    context "when the interval is an integer" do
+      let(:config_data) do
+        BASE_CONFIG_DATA.merge("interval" => 60)
+      end
+
+      before do
+        config.apply_config_values(config_data)
+      end
+
+      it "sets the interval" do
+        expect(config.interval).to eq(60)
+      end
+    end
+
+    context "when the interval is a string of numbers" do
+      let(:config_data) do
+        BASE_CONFIG_DATA.merge("interval" => "65")
+      end
+
+      before do
+        config.apply_config_values(config_data)
+      end
+
+      it "sets the interval" do
+        expect(config.interval).to eq(65)
+      end
+    end
+
+    context "when the interval is a string that contains characters" do
+      let(:config_data) do
+        BASE_CONFIG_DATA.merge("interval" => "not seconds")
+      end
+
+      it "raises an error" do
+        expect { config.apply_config_values(config_data) }.to raise_error(AutomateLivenessAgent::ConfigError, /is not an integer/)
+      end
+    end
+
+    context "when the interval is nil" do
+      let(:config_data) do
+        BASE_CONFIG_DATA.merge("interval" => nil)
+      end
+
+      before do
+        config.apply_config_values(config_data)
+      end
+
+      it "sets the interval to nil" do
+        expect(config.interval).to eq(nil)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Some service providers won't pass `INTERVAL=2` in the tests from the
chef-client environment to the liveness agent's environment.

This leaves the agent on an 1800 second interval causing one of the
tests to fail (test-002 after setup-002 resets the pings).

This change allows interval to be read from the config.json, as well as
will write an interval to the config.json if it is seen in the
environment.

This causes `supported-ubuntu-1604` to pass where it is currently failing with:
```
  ✔  setup-001: converge previous stable version
     ✔  Command INTERVAL=2 chef-client -z -c /tmp/kitchen/test-client.rb -j /tmp/kitchen/test-stable-attrs.json exit_status should eq 0
  ✔  test-001: upgrade by converging the compiled recipe artifact
     ✔  Command INTERVAL=2 chef-client -z -c /tmp/kitchen/test-client.rb -j /tmp/kitchen/test-current-attrs.json exit_status should eq 0
  ✔  setup-002: reset the automate ping counter
     ✔  http GET on http://localhost:9292/organizations/ubuntu1604/reset-pings status should cmp == 200
     ✔  http GET on http://localhost:9292/organizations/ubuntu1604/reset-pings body should cmp == "0"
  ✔  setup-003: sleep to let the liveness agent send some pings
     ✔  Command sleep 10 exit_status should eq 0
  ∅  test-002: verify that the pings count has increased (1 failed)
     ∅  http GET on http://localhost:9292/organizations/ubuntu1604/pings body should not cmp == "0"
     
     expected it not to be == "0"
          got: 0
     
     (compared using `cmp` matcher)

     ✔  http GET on http://localhost:9292/organizations/ubuntu1604/pings status should eq 200
  ✔  test-003: verify that the recipe can converge again without error
     ✔  Command INTERVAL=2 chef-client -z -c /tmp/kitchen/test-client.rb -j /tmp/kitchen/test-current-attrs.json exit_status should eq 0
  ✔  test-004: verify that the agent is logging correctly
     ✔  File /var/log/chef/automate-liveness-agent/automate-liveness-agent.log should be file
     ✔  File /var/log/chef/automate-liveness-agent/automate-liveness-agent.log should be owned by "chefautomate"
     ✔  File /var/log/chef/automate-liveness-agent/automate-liveness-agent.log should be readable
     ✔  File /var/log/chef/automate-liveness-agent/automate-liveness-agent.log content should match /201 Created/


Profile Summary: 6 successful controls, 1 control failure, 0 controls skipped
Test Summary: 11 successful, 1 failure, 0 skipped
```