### PR TITLE
Use bundle-exec when running tests

### DIFF
--- a/RELEASE_PLAN.md
+++ b/RELEASE_PLAN.md
@@ -16,9 +16,9 @@ Run the full kitchen acceptance suite to verify recipe upgrade, convergence,
 re-convergence, and liveness agent logging and pings.
 
 ```
-rake compile_recipe
-kitchen converge automate
-kitchen test supported
+bundle exec rake compile_recipe
+bundle exec kitchen converge automate
+bundle exec kitchen test supported
 ```
 
 ##### Init Script Acceptance Test


### PR DESCRIPTION
I found that if I didn't use `bundle exec` for the `kitchen test`
command, I got failures caused by differences in the inspec `cmp`
function.

Signed-off-by: Steven Danna <steve@chef.io>