### PR TITLE
Fix the bin setup in the gemspec

### DIFF
--- a/automate-liveness-agent.gemspec
+++ b/automate-liveness-agent.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir        = "bin"
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.14"


### PR DESCRIPTION
There isn't an exe dir. Fix it to be the bin dir.

Signed-off-by: Tim Smith <tsmith@chef.io>