### PR TITLE
Use node_uuid method instead of parsing data collector metadata

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -217,27 +217,40 @@ platforms:
     verifier:
       attributes:
         org_name: centos6812
-  - name: centos-7.3
+  - name: centos-7.6
     attributes:
       liveness-agent-test:
         automate:
-          org_name: centos73
+          org_name: centos76
     verifier:
       attributes:
-        org_name: centos73
-  - name: centos-7.3-12
+        org_name: centos76
+  - name: centos-7.6-12
     provisioner:
       product_name: chef
       product_version: 12
     driver:
-      box: bento/centos-7.3
+      box: bento/centos-7.6
     attributes:
       liveness-agent-test:
         automate:
-          org_name: centos7312
+          org_name: centos7612
     verifier:
       attributes:
-        org_name: centos7312
+        org_name: centos7612
+  - name: centos-7.6-13
+    provisioner:
+      product_name: chef
+      product_version: 13
+    driver:
+      box: bento/centos-7.6
+    attributes:
+      liveness-agent-test:
+        automate:
+          org_name: centos7613
+    verifier:
+      attributes:
+        org_name: centos7613
   #
   # amazon linux
   #
@@ -897,8 +910,9 @@ suites:
       - centos-5.11-12
       - centos-6.8
       - centos-6.8-12
-      - centos-7.3
-      - centos-7.3-12
+      - centos-7.6
+      - centos-7.6-12
+      - centos-7.6-13
       - amazon-linux
       - amazon-linux-12
       - win-2008-std-12

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 2.3.3
   - 2.4.1
+  - 2.5.0
 
 env:
   -
@@ -16,7 +17,7 @@ branches:
 matrix:
   exclude:
     # Only execute the linting checks once
-    - rvm: 2.3.3
+    - rvm: 2.5.0
       env: CHEFSTYLE=true
-    - rvm: 2.3.3
+    - rvm: 2.5.0
       env: COOKSTYLE=true

--- a/lib/automate_liveness_agent/version.rb
+++ b/lib/automate_liveness_agent/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module AutomateLivenessAgent
-  VERSION = "0.7.5"
+  VERSION = "0.7.6"
 end

--- a/lib/recipe.rb
+++ b/lib/recipe.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 # rubocop:disable Layout/SpaceAroundOperators
 
-#  Copyright 2017 Chef Software, Inc.
+#  Copyright 2019 Chef Software, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -183,7 +183,7 @@ file agent_conf do
         "client_name"         => node.name,
         "daemon_mode"					=> daemon_mode,
         "data_collector_url"  => Chef::Config[:data_collector][:server_url],
-        "entity_uuid"         => Chef::JSONCompat.parse(Chef::FileCache.load("data_collector_metadata.json"))["node_uuid"],
+        "entity_uuid"         => Chef::DataCollector::Messages.node_uuid,
         "install_check_file"  => Gem.ruby,
         "org_name"            => Chef::Config[:data_collector][:organization] || server_uri.path.split("/").last,
         "unprivileged_uid"    => platform?("windows") || platform?("aix") ? nil : Etc.getpwnam(agent_username).uid,


### PR DESCRIPTION
## Description
Newer versions of the chef-client may prefer the client GUID over the
data collector UUID. Instead of relying on the storage file we'll use
the existing helper.

This change also:
  * Fixes an rspec test
  * Updates to the latest centos 7 bento box
  * Add a chef-client 14 centos 7 test

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
