### PR TITLE
Chef-15 fixes for `node[:chef_guid]`

### DIFF
--- a/lib/recipe.rb
+++ b/lib/recipe.rb
@@ -183,6 +183,7 @@ file agent_conf do
         "client_name"         => node.name,
         "daemon_mode"         => daemon_mode,
         "data_collector_url"  => Chef::Config[:data_collector][:server_url],
+        # the Chef::DataCollector::Messages API here is Chef < 15.0 backcompat and can be removed when Chef 14.x is no longer supported
         "entity_uuid"         => node[:chef_guid] || defined?(Chef::DataCollector::Messages) && Chef::DataCollector::Messages.node_uuid,
         "install_check_file"  => Gem.ruby,
         "org_name"            => Chef::Config[:data_collector][:organization] || server_uri.path.split("/").last,

--- a/lib/recipe.rb
+++ b/lib/recipe.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 # rubocop:disable Layout/SpaceAroundOperators
 
-#  Copyright 2019 Chef Software, Inc.
+#  Copyright 2019-2019, Chef Software Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -181,9 +181,9 @@ file agent_conf do
         "chef_server_fqdn"    => server_uri.host,
         "client_key_path"     => Chef::Config[:client_key],
         "client_name"         => node.name,
-        "daemon_mode"					=> daemon_mode,
+        "daemon_mode"         => daemon_mode,
         "data_collector_url"  => Chef::Config[:data_collector][:server_url],
-        "entity_uuid"         => Chef::DataCollector::Messages.node_uuid,
+        "entity_uuid"         => node[:chef_guid] || defined?(Chef::DataCollector::Messages) && Chef::DataCollector::Messages.node_uuid,
         "install_check_file"  => Gem.ruby,
         "org_name"            => Chef::Config[:data_collector][:organization] || server_uri.path.split("/").last,
         "unprivileged_uid"    => platform?("windows") || platform?("aix") ? nil : Etc.getpwnam(agent_username).uid,


### PR DESCRIPTION
    The public API for this now has nothing to do with the DataCollector.

    In Chef-15 the `node[:chef_guid]` is created for every single Chef-15
    node, doesn't matter if the node is using the data collector or not.

    The DataCollector then consumes that.

    All the internals of the DataCollector have changed and reading the
    guid out of the DataCollector is no longer a public UI of the DC.

    The crazysauce with the multiple metadata files is also gone, along with the
    data_collector_metadata.json file itself (which the prior PR #67 here
    independently discovered).

    Included backcompat here for Chef < 15.0 implementations which still
    have the Chef::DataCollector::Messages class.